### PR TITLE
rustfmt: Use rustfmt from tooling

### DIFF
--- a/.github/workflows/lint_clippy.yml
+++ b/.github/workflows/lint_clippy.yml
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-name: rustfmt and clippy check
+name: clippy check
 
 on:
   pull_request:
@@ -21,7 +21,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
-  lint-fmt-clippy:
+  lint-clippy:
     timeout-minutes: 6 # 6 minutes is the maximum allowed for a cold run
     runs-on: ${{ vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
     steps:
@@ -42,9 +42,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-lint-fmt-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-lint-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-lint-fmt-clippy-
+            ${{ runner.os }}-cargo-lint-clippy-
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -52,13 +52,7 @@ jobs:
           profile: minimal
           toolchain: 1.90.0
           override: true
-          components: rustfmt, clippy
-
-      - name: check code format (rustfmt)
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+          components: clippy
 
       - name: check clippy errors
         uses: actions-rs/cargo@v1

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,7 +28,8 @@ bazel_dep(name = "platforms", version = "1.0.0")
 # S-CORE process rules
 bazel_dep(name = "score_bazel_platforms", version = "0.0.2")
 bazel_dep(name = "score_docs_as_code", version = "2.0.2")
-bazel_dep(name = "score_tooling", version = "1.0.2")
+bazel_dep(name = "score_tooling", version = "1.0.4")
+bazel_dep(name = "score_rust_policies", version = "0.0.2")
 
 bazel_dep(name = "score_process", version = "1.3.1", dev_dependency = True)
 bazel_dep(name = "score_platform", version = "0.4.2", dev_dependency = True)  # This is main score repo
@@ -46,7 +47,7 @@ bazel_dep(name = "score_crates")
 # Overrides
 git_override(
     module_name = "score_tooling",
-    commit = "654664dae7df2700fd5840c5ed6c07ac6c61705d",  #until 1.0.4 is released
+    commit = "f484bc23485b0880d8d86e96b8f25d7650889089",  #until 1.0.5 is released
     remote = "https://github.com/eclipse-score/tooling.git",
 )
 

--- a/src/containers/fixed_capacity/queue.rs
+++ b/src/containers/fixed_capacity/queue.rs
@@ -33,7 +33,10 @@ impl<T> FixedCapacityQueue<T> {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        assert!(capacity <= u32::MAX as usize, "FixedQueue can hold at most u32::MAX elements");
+        assert!(
+            capacity <= u32::MAX as usize,
+            "FixedQueue can hold at most u32::MAX elements"
+        );
         Self {
             inner: GenericQueue::new(capacity as u32),
         }

--- a/src/containers/fixed_capacity/vec.rs
+++ b/src/containers/fixed_capacity/vec.rs
@@ -34,7 +34,10 @@ impl<T> FixedCapacityVec<T> {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        assert!(capacity <= u32::MAX as usize, "FixedCapacityVec can hold at most u32::MAX elements");
+        assert!(
+            capacity <= u32::MAX as usize,
+            "FixedCapacityVec can hold at most u32::MAX elements"
+        );
         Self {
             inner: GenericVec::new(capacity as u32),
         }

--- a/src/containers/generic/queue.rs
+++ b/src/containers/generic/queue.rs
@@ -128,7 +128,11 @@ impl<T, S: Storage<T>> GenericQueue<T, S> {
     pub fn push_front(&mut self, value: T) -> Result<&mut T, QueueFull> {
         let capacity = self.storage.capacity();
         if self.len < capacity {
-            let write_pos = if self.front_index > 0 { self.front_index - 1 } else { capacity - 1 };
+            let write_pos = if self.front_index > 0 {
+                self.front_index - 1
+            } else {
+                capacity - 1
+            };
             let element = unsafe { self.storage.element_mut(write_pos).write(value) };
             self.len += 1;
             self.front_index = write_pos;

--- a/src/containers/storage/heap.rs
+++ b/src/containers/storage/heap.rs
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
-use alloc::alloc::Layout;
 use alloc::alloc::alloc;
 use alloc::alloc::dealloc;
+use alloc::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ptr;
@@ -50,8 +50,12 @@ impl<T> Storage<T> for Heap<T> {
                 )
             });
             // SAFETY: `layout` has a non-zero size (because `capacity` is > 0)
-            NonNull::new(unsafe { alloc(layout) })
-                .unwrap_or_else(|| panic!("failed to allocate {capacity} elements of {typ}", typ = core::any::type_name::<T>()))
+            NonNull::new(unsafe { alloc(layout) }).unwrap_or_else(|| {
+                panic!(
+                    "failed to allocate {capacity} elements of {typ}",
+                    typ = core::any::type_name::<T>()
+                )
+            })
         } else {
             NonNull::dangling()
         };
@@ -141,11 +145,20 @@ mod tests {
             if capacity > 2 {
                 let partial_slice = unsafe { instance.subslice(1, 2) };
                 assert_eq!(partial_slice.len(), 1);
-                assert_eq!(partial_slice as *const T, instance.elements.as_ptr().wrapping_add(1));
+                assert_eq!(
+                    partial_slice as *const T,
+                    instance.elements.as_ptr().wrapping_add(1)
+                );
 
                 let end_slice = unsafe { instance.subslice(capacity - 1, capacity) };
                 assert_eq!(end_slice.len(), 1);
-                assert_eq!(end_slice as *const T, instance.elements.as_ptr().wrapping_add(capacity as usize - 1));
+                assert_eq!(
+                    end_slice as *const T,
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1)
+                );
             }
         }
 
@@ -172,11 +185,20 @@ mod tests {
             if capacity >= 2 {
                 let partial_slice = unsafe { instance.subslice_mut(1, 2) };
                 assert_eq!(partial_slice.len(), 1);
-                assert_eq!(partial_slice as *mut T, instance.elements.as_ptr().wrapping_add(1));
+                assert_eq!(
+                    partial_slice as *mut T,
+                    instance.elements.as_ptr().wrapping_add(1)
+                );
 
                 let end_slice = unsafe { instance.subslice_mut(capacity - 1, capacity) };
                 assert_eq!(end_slice.len(), 1);
-                assert_eq!(end_slice as *mut T, instance.elements.as_ptr().wrapping_add(capacity as usize - 1));
+                assert_eq!(
+                    end_slice as *mut T,
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1)
+                );
             }
         }
 
@@ -197,15 +219,30 @@ mod tests {
                 assert_eq!(first_element.as_ptr(), instance.elements.as_ptr());
 
                 let last_element = unsafe { instance.element(capacity - 1) };
-                assert_eq!(last_element.as_ptr(), instance.elements.as_ptr().wrapping_add(capacity as usize - 1));
+                assert_eq!(
+                    last_element.as_ptr(),
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1)
+                );
             }
 
             if capacity >= 2 {
                 let second_element = unsafe { instance.element(1) };
-                assert_eq!(second_element.as_ptr(), instance.elements.as_ptr().wrapping_add(1));
+                assert_eq!(
+                    second_element.as_ptr(),
+                    instance.elements.as_ptr().wrapping_add(1)
+                );
 
                 let last_element = unsafe { instance.element(capacity - 2) };
-                assert_eq!(last_element.as_ptr(), instance.elements.as_ptr().wrapping_add(capacity as usize - 2));
+                assert_eq!(
+                    last_element.as_ptr(),
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 2)
+                );
             }
         }
 
@@ -226,15 +263,30 @@ mod tests {
                 assert_eq!(first_element.as_ptr(), instance.elements.as_ptr());
 
                 let last_element = unsafe { instance.element_mut(capacity - 1) };
-                assert_eq!(last_element.as_ptr(), instance.elements.as_ptr().wrapping_add(capacity as usize - 1));
+                assert_eq!(
+                    last_element.as_ptr(),
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1)
+                );
             }
 
             if capacity >= 2 {
                 let second_element = unsafe { instance.element_mut(1) };
-                assert_eq!(second_element.as_ptr(), instance.elements.as_ptr().wrapping_add(1));
+                assert_eq!(
+                    second_element.as_ptr(),
+                    instance.elements.as_ptr().wrapping_add(1)
+                );
 
                 let last_element = unsafe { instance.element_mut(capacity - 2) };
-                assert_eq!(last_element.as_ptr(), instance.elements.as_ptr().wrapping_add(capacity as usize - 2));
+                assert_eq!(
+                    last_element.as_ptr(),
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 2)
+                );
             }
         }
 

--- a/src/containers/storage/inline.rs
+++ b/src/containers/storage/inline.rs
@@ -103,22 +103,34 @@ mod tests {
 
             let empty_slice = unsafe { instance.subslice(0, 0) };
             assert_eq!(empty_slice.len(), 0);
-            assert_eq!(empty_slice as *const T, instance.elements.as_ptr() as *const T);
+            assert_eq!(
+                empty_slice as *const T,
+                instance.elements.as_ptr() as *const T
+            );
 
             let full_slice = unsafe { instance.subslice(0, capacity) };
             assert_eq!(full_slice.len(), capacity as usize);
-            assert_eq!(full_slice as *const T, instance.elements.as_ptr() as *const T);
+            assert_eq!(
+                full_slice as *const T,
+                instance.elements.as_ptr() as *const T
+            );
 
             if capacity > 2 {
                 let partial_slice = unsafe { instance.subslice(1, 2) };
                 assert_eq!(partial_slice.len(), 1);
-                assert_eq!(partial_slice as *const T, instance.elements.as_ptr().wrapping_add(1) as *const T);
+                assert_eq!(
+                    partial_slice as *const T,
+                    instance.elements.as_ptr().wrapping_add(1) as *const T
+                );
 
                 let end_slice = unsafe { instance.subslice(capacity - 1, capacity) };
                 assert_eq!(end_slice.len(), 1);
                 assert_eq!(
                     end_slice as *const T,
-                    instance.elements.as_ptr().wrapping_add(capacity as usize - 1) as *const T
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1) as *const T
                 );
             }
         }
@@ -149,13 +161,19 @@ mod tests {
             if capacity >= 2 {
                 let partial_slice = unsafe { instance.subslice_mut(1, 2) };
                 assert_eq!(partial_slice.len(), 1);
-                assert_eq!(partial_slice as *mut T, instance.elements.as_ptr().wrapping_add(1) as *mut T);
+                assert_eq!(
+                    partial_slice as *mut T,
+                    instance.elements.as_ptr().wrapping_add(1) as *mut T
+                );
 
                 let end_slice = unsafe { instance.subslice_mut(capacity - 1, capacity) };
                 assert_eq!(end_slice.len(), 1);
                 assert_eq!(
                     end_slice as *mut T,
-                    instance.elements.as_ptr().wrapping_add(capacity as usize - 1) as *mut T
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1) as *mut T
                 );
             }
         }
@@ -177,23 +195,35 @@ mod tests {
 
             if capacity >= 1 {
                 let first_element = unsafe { instance.element(0) };
-                assert_eq!(first_element.as_ptr(), instance.elements.as_ptr() as *const T);
+                assert_eq!(
+                    first_element.as_ptr(),
+                    instance.elements.as_ptr() as *const T
+                );
 
                 let last_element = unsafe { instance.element(capacity - 1) };
                 assert_eq!(
                     last_element.as_ptr(),
-                    instance.elements.as_ptr().wrapping_add(capacity as usize - 1) as *const T,
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1) as *const T,
                 );
             }
 
             if capacity >= 2 {
                 let second_element = unsafe { instance.element(1) };
-                assert_eq!(second_element.as_ptr(), instance.elements.as_ptr().wrapping_add(1) as *const T);
+                assert_eq!(
+                    second_element.as_ptr(),
+                    instance.elements.as_ptr().wrapping_add(1) as *const T
+                );
 
                 let last_element = unsafe { instance.element(capacity - 2) };
                 assert_eq!(
                     last_element.as_ptr(),
-                    instance.elements.as_ptr().wrapping_add(capacity as usize - 2) as *const T,
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 2) as *const T,
                 );
             }
         }
@@ -220,18 +250,27 @@ mod tests {
                 let last_element = unsafe { instance.element_mut(capacity - 1) };
                 assert_eq!(
                     last_element.as_ptr(),
-                    instance.elements.as_ptr().wrapping_add(capacity as usize - 1) as *mut T,
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 1) as *mut T,
                 );
             }
 
             if capacity >= 2 {
                 let second_element = unsafe { instance.element_mut(1) };
-                assert_eq!(second_element.as_ptr(), instance.elements.as_ptr().wrapping_add(1) as *mut T);
+                assert_eq!(
+                    second_element.as_ptr(),
+                    instance.elements.as_ptr().wrapping_add(1) as *mut T
+                );
 
                 let last_element = unsafe { instance.element_mut(capacity - 2) };
                 assert_eq!(
                     last_element.as_ptr(),
-                    instance.elements.as_ptr().wrapping_add(capacity as usize - 2) as *mut T,
+                    instance
+                        .elements
+                        .as_ptr()
+                        .wrapping_add(capacity as usize - 2) as *mut T,
                 );
             }
         }


### PR DESCRIPTION
Rules: https://github.com/eclipse-score/score_rust_policies/blob/main/rustfmt/rustfmt.toml

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes https://github.com/eclipse-score/score/issues/2011

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
