### PR TITLE
log: add `Box` format impl

### DIFF
--- a/src/log/mw_log_fmt/fmt_impl.rs
+++ b/src/log/mw_log_fmt/fmt_impl.rs
@@ -170,6 +170,12 @@ impl<T: ScoreDebug> ScoreDebug for Option<T> {
     }
 }
 
+impl<T: ScoreDebug + ?Sized> ScoreDebug for Box<T> {
+    fn fmt(&self, f: Writer, spec: &FormatSpec) -> Result {
+        ScoreDebug::fmt(&**self, f, spec)
+    }
+}
+
 impl<K, V, S> ScoreDebug for std::collections::HashMap<K, V, S>
 where
     K: ScoreDebug,
@@ -324,6 +330,11 @@ mod tests {
     fn test_option_debug() {
         common_test_debug(Some(123));
         common_test_debug(Option::<i32>::None);
+    }
+
+    #[test]
+    fn test_box_debug() {
+        common_test_debug(Box::new(432.1));
     }
 
     #[test]


### PR DESCRIPTION
Add `Box` format to common implementations.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
