### PR TITLE
log: re-export `qm` feature in `mw_log`

### DIFF
--- a/src/log/mw_log/Cargo.toml
+++ b/src/log/mw_log/Cargo.toml
@@ -25,5 +25,8 @@ path = "lib.rs"
 mw_log_fmt.workspace = true
 mw_log_fmt_macro.workspace = true
 
+[features]
+qm = ["mw_log_fmt/qm"]
+
 [lints]
 workspace = true


### PR DESCRIPTION
`qm` belongs to `mw_log_fmt`, which is a hidden dep. Export `qm` so that it can be used externally.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
