### PR TITLE
Testing macro crate: Auto init logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "score_testing_macros"
+version = "0.0.1"
+dependencies = [
+ "quote",
+ "stdout_logger",
+ "syn",
+]
+
+[[package]]
 name = "stdout_logger"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default-members = [
     "src/elementary",
     "src/log/score_log_fmt_macro",
     "src/log/stdout_logger",
+    "src/testing_macros",
 ]
 # Include tests and examples as a member for IDE support and Bazel builds.
 members = [
@@ -31,6 +32,7 @@ members = [
     "src/log/score_log_fmt",
     "src/log/score_log_fmt_macro",
     "src/log/stdout_logger",
+    "src/testing_macros",
     "examples/log_builtin",
     "examples/log_custom",
 ]
@@ -47,6 +49,7 @@ score_log_fmt = { path = "src/log/score_log_fmt" }
 score_log_fmt_macro = { path = "src/log/score_log_fmt_macro" }
 stdout_logger = { path = "src/log/stdout_logger" }
 elementary = { path = "src/elementary" }
+testing_macros = { path = "src/testing_macros" }
 
 [workspace.lints.clippy]
 std_instead_of_core = "warn"

--- a/src/log/stdout_logger/lib.rs
+++ b/src/log/stdout_logger/lib.rs
@@ -204,11 +204,18 @@ impl StdoutLoggerBuilder {
 
     /// Build the `StdoutLogger` and set it as the default logger.
     pub fn set_as_default_logger(self) {
-        let logger = self.build();
-        score_log::set_max_level(logger.log_level());
-        if let Err(e) = score_log::set_global_logger(Box::new(logger)) {
+        if let Err(e) = self.try_set_as_default_logger() {
             panic!("unable to set logger: {e}");
         }
+    }
+
+    /// Build the `StdoutLogger` and try to set it as the default logger.
+    pub fn try_set_as_default_logger(self) -> core::result::Result<(), score_log::SetLoggerError> {
+        let logger = self.build();
+        let level = logger.log_level();
+        score_log::set_global_logger(Box::new(logger))?;
+        score_log::set_max_level(level);
+        Ok(())
     }
 }
 
@@ -291,6 +298,8 @@ impl Log for StdoutLogger {
     }
 
     fn flush(&self) {
-        // No-op.
+        use std::io::Write;
+        let mut stdout = std::io::stdout();
+        stdout.flush().unwrap();
     }
 }

--- a/src/testing_macros/BUILD
+++ b/src/testing_macros/BUILD
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
+
+rust_proc_macro(
+    name = "score_testing_macros",
+    srcs = glob(["*.rs"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/log/stdout_logger",
+        "@score_crates//:quote",
+        "@score_crates//:syn",
+    ],
+)

--- a/src/testing_macros/Cargo.toml
+++ b/src/testing_macros/Cargo.toml
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+[package]
+name = "score_testing_macros"
+version.workspace = true
+authors.workspace = true
+readme.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+path = "lib.rs"
+
+[dependencies]
+syn = { version = "2" }
+quote = "1"
+stdout_logger.workspace = true

--- a/src/testing_macros/lib.rs
+++ b/src/testing_macros/lib.rs
@@ -1,0 +1,71 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn, ItemMod};
+
+/// Attribute macro to create a test function with stdout logger initialized.
+#[proc_macro_attribute]
+pub fn test_with_log(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let block = &input.block;
+    let attrs = &input.attrs;
+
+    TokenStream::from(quote! {
+        #(#attrs)*
+        #vis #sig {
+            let _ = stdout_logger::StdoutLoggerBuilder::new()
+                .context("TEST")
+                .log_level(score_log::LevelFilter::Trace)
+                .try_set_as_default_logger();
+            #block
+            score_log::global_logger().flush();
+        }
+    })
+}
+
+/// Attribute macro that modifies a test module to initialize stdout logger for each test.
+#[proc_macro_attribute]
+pub fn test_mod_with_log(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as ItemMod);
+
+    if let Some((_, ref mut items)) = input.content {
+        // Wrap each #[test] function to call test_hook automatically
+        for item in items.iter_mut() {
+            if let syn::Item::Fn(ref mut f) = item {
+                let is_test = f.attrs.iter().any(|a| a.path().is_ident("test"));
+                if is_test {
+                    let block = &f.block;
+                    f.block = syn::parse_quote!({
+
+                        let _ = stdout_logger::StdoutLoggerBuilder::new()
+                            .context("TEST")
+                            .log_level(score_log::LevelFilter::Trace)
+                            .try_set_as_default_logger();
+                        #block
+
+                        score_log::global_logger().flush();
+                    });
+                }
+            }
+        }
+    }
+
+    TokenStream::from(quote! {
+        #input
+    })
+}


### PR DESCRIPTION
To ease testing experience in other crates this
crate provies extensions. Currently added

- test_with_log - enables stdout_logger as backend for score_log

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
