### PR TITLE
log: add Rust log init for C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,48 @@
+BasedOnStyle: Google
+AccessModifierOffset: -2
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+# Empty is required in AllowShortFunctionsOnASingleLine over Inline because Inline contradicts with AUTOSAR rule A7-1-7
+# Such rule is no longer existing in MISRA C++:2023, once we are fully migrated to MISRA C++:2023, switching to Inline
+# could be reconsidered
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+BreakBeforeBraces: Custom
+ColumnLimit: 120
+DerivePointerAlignment: false
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^(<|")(assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdargh|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h(>|")$'
+    Priority: 2
+  - Regex: '^(<|")(cstdlib|csignal|csetjmp|cstdarg|typeinfo|typeindex|type_traits|bitset|functional|utility|ctime|chrono|cstddef|initializer_list|tuple|any|optional|variant|new|memory|scoped_allocator|memory_resource|climits|cfloat|cstdint|cinttypes|limits|exception|stdexcept|cassert|system_error|cerrno|cctype|cwctype|cstring|cwchar|cuchar|string|string_view|array|vector|deque|list|forward_list|set|map|unordered_set|unordered_map|stack|queue|algorithm|execution|teratorslibrary|iterator|cmath|complex|valarray|random|numeric|ratio|cfenv|iosfwd|ios|istream|ostream|iostream|fstream|sstream|strstream|iomanip|streambuf|cstdio|locale|clocale|codecvt|regex|atomic|thread|mutex|shared_mutex|future|condition_variable|filesystem|ciso646|ccomplex|ctgmath|cstdalign|cstdbool)(>|")$'
+    Priority: 3
+  - Regex: '^(<|").*(>|")$'
+    Priority: 1
+IndentWidth: 4
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+QualifierAlignment: Left
+CommentPragmas: '^.*A2Lfactory:'
+---
+# Make sure language specific settings are below the generic settings to be compatible to all languages.
+Language: Cpp
+Standard: c++17

--- a/examples/log_cpp_init/BUILD
+++ b/examples/log_cpp_init/BUILD
@@ -1,0 +1,37 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_rust//rust:defs.bzl", "rust_static_library")
+
+rust_static_library(
+    name = "example_lib",
+    srcs = ["src/example_lib.rs"],
+    edition = "2021",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/log/score_log",
+        "//src/log/stdout_logger",
+    ],
+)
+
+cc_binary(
+    name = "log_cpp_init",
+    srcs = ["src/main.cpp"],
+    linkopts = ["-lpthread"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":example_lib",
+        "//src/log/stdout_logger_cpp_init",
+    ],
+)

--- a/examples/log_cpp_init/src/example_lib.rs
+++ b/examples/log_cpp_init/src/example_lib.rs
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Module contains functions printing example logs.
+//! Based on `//score/mw/log/rust/score_log_bridge:example`.
+
+use score_log::{debug, error, fatal, info, trace, warn, Log};
+use stdout_logger::StdoutLoggerBuilder;
+
+/// Show example logs.
+#[no_mangle]
+extern "C" fn show_logs() {
+    // Regular log usage.
+    trace!("This is a trace log - hidden");
+    debug!("This is a debug log - hidden");
+    info!("This is an info log");
+    warn!("This is a warn log");
+    error!("This is an error log");
+    fatal!("This is a fatal log");
+
+    // Log with modified context.
+    trace!(context: "EX1", "This is a trace log - hidden");
+    debug!(context: "EX1", "This is a debug log - hidden");
+    info!(context: "EX1", "This is an info log");
+    warn!(context: "EX1", "This is a warn log");
+    error!(context: "EX1", "This is an error log");
+    fatal!(context: "EX1", "This is a fatal log");
+
+    // Log with numeric values.
+    let x1 = 123.4;
+    let x2 = 111;
+    let x3 = true;
+    let x4 = -0x3Fi8;
+    error!(
+        "This is an error log with numeric values: {} {} {} {:x}",
+        x1, x2, x3, x4,
+    );
+
+    // Use logger instance with modified context.
+    let logger = StdoutLoggerBuilder::new()
+        .context("ALFA")
+        .show_module(false)
+        .show_file(true)
+        .show_line(false)
+        .build();
+
+    // Log with provided logger.
+    trace!(
+        logger: logger,
+        "This is a trace log - hidden"
+    );
+    debug!(logger: logger, "This is a debug log - hidden");
+    info!(logger: logger, "This is an info log");
+    warn!(logger: logger, "This is a warn log");
+    error!(logger: logger, "This is an error log");
+    fatal!(logger: logger, "This is an fatal log");
+
+    // Log with provided logger and modified context.
+    trace!(logger: logger, context: "EX2", "This is a trace log - hidden");
+    debug!(logger: logger, context: "EX2", "This is a debug log - hidden");
+    info!(logger: logger, context: "EX2", "This is an info log");
+    warn!(logger: logger, context: "EX2", "This is a warn log");
+    error!(logger: logger, context: "EX2", "This is an error log");
+    fatal!(logger: logger, context: "EX2", "This is an fatal log");
+}

--- a/examples/log_cpp_init/src/main.cpp
+++ b/examples/log_cpp_init/src/main.cpp
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/log/rust/stdout_logger_init.h"
+
+extern "C" {
+void show_logs();
+}
+
+int main()
+{
+    using namespace score::mw::log::rust;
+
+    StdoutLoggerBuilder builder;
+    builder.Context("ABCD").ShowModule(true).ShowFile(true).ShowLine(true).SetAsDefaultLogger();
+
+    show_logs();
+
+    return 0;
+}

--- a/src/log/stdout_logger_cpp_init/BUILD
+++ b/src/log/stdout_logger_cpp_init/BUILD
@@ -1,0 +1,37 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_rust//rust:defs.bzl", "rust_static_library")
+
+rust_static_library(
+    name = "ffi",
+    srcs = ["ffi.rs"],
+    edition = "2021",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/log/score_log",
+        "//src/log/stdout_logger",
+    ],
+)
+
+cc_library(
+    name = "stdout_logger_cpp_init",
+    srcs = ["stdout_logger_init.cpp"],
+    hdrs = ["stdout_logger_init.h"],
+    include_prefix = "score/mw/log/rust",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ffi",
+    ],
+)

--- a/src/log/stdout_logger_cpp_init/ffi.rs
+++ b/src/log/stdout_logger_cpp_init/ffi.rs
@@ -1,0 +1,83 @@
+//
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use core::ffi::c_char;
+use core::slice::from_raw_parts;
+use stdout_logger::StdoutLoggerBuilder;
+
+/// Represents severity of a log message.
+#[derive(Clone, Copy)]
+#[repr(u8)]
+#[allow(dead_code)]
+enum LogLevel {
+    Off = 0x00,
+    Fatal = 0x01,
+    Error = 0x02,
+    Warn = 0x03,
+    Info = 0x04,
+    Debug = 0x05,
+    Verbose = 0x06,
+}
+
+impl From<LogLevel> for score_log::LevelFilter {
+    fn from(level: LogLevel) -> score_log::LevelFilter {
+        match level {
+            LogLevel::Off => score_log::LevelFilter::Off,
+            LogLevel::Fatal => score_log::LevelFilter::Fatal,
+            LogLevel::Error => score_log::LevelFilter::Error,
+            LogLevel::Warn => score_log::LevelFilter::Warn,
+            LogLevel::Info => score_log::LevelFilter::Info,
+            LogLevel::Debug => score_log::LevelFilter::Debug,
+            LogLevel::Verbose => score_log::LevelFilter::Trace,
+        }
+    }
+}
+
+#[no_mangle]
+extern "C" fn set_default_logger(
+    context_ptr: *const c_char,
+    context_size: usize,
+    show_module: *const bool,
+    show_file: *const bool,
+    show_line: *const bool,
+    log_level: *const LogLevel,
+) {
+    let mut builder = StdoutLoggerBuilder::new();
+
+    // Set parameters if non-null (option-like).
+    if !context_ptr.is_null() {
+        let context = unsafe {
+            let slice = from_raw_parts(context_ptr.cast(), context_size);
+            str::from_utf8_unchecked(slice)
+        };
+        builder = builder.context(context);
+    }
+
+    if !show_module.is_null() {
+        builder = builder.show_module(unsafe { *show_module });
+    }
+
+    if !show_file.is_null() {
+        builder = builder.show_file(unsafe { *show_file });
+    }
+
+    if !show_line.is_null() {
+        builder = builder.show_line(unsafe { *show_line });
+    }
+
+    if !log_level.is_null() {
+        builder = builder.log_level(unsafe { (*log_level).into() });
+    }
+
+    builder.set_as_default_logger();
+}

--- a/src/log/stdout_logger_cpp_init/stdout_logger_init.cpp
+++ b/src/log/stdout_logger_cpp_init/stdout_logger_init.cpp
@@ -1,0 +1,75 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "stdout_logger_init.h"
+
+extern "C" void set_default_logger(const char* context_ptr,
+                                   size_t context_size,
+                                   const bool* show_module,
+                                   const bool* show_file,
+                                   const bool* show_line,
+                                   const score::mw::log::rust::LogLevel* log_level);
+
+namespace score::mw::log::rust
+{
+
+StdoutLoggerBuilder& StdoutLoggerBuilder::Context(const std::string& context) noexcept
+{
+    context_ = context;
+    return *this;
+}
+
+StdoutLoggerBuilder& StdoutLoggerBuilder::ShowModule(bool show_module) noexcept
+{
+    show_module_ = show_module;
+    return *this;
+}
+
+StdoutLoggerBuilder& StdoutLoggerBuilder::ShowFile(bool show_file) noexcept
+{
+    show_file_ = show_file;
+    return *this;
+}
+
+StdoutLoggerBuilder& StdoutLoggerBuilder::ShowLine(bool show_line) noexcept
+{
+    show_line_ = show_line;
+    return *this;
+}
+
+StdoutLoggerBuilder& StdoutLoggerBuilder::LogLevel(score::mw::log::rust::LogLevel log_level) noexcept
+{
+    log_level_ = log_level;
+    return *this;
+}
+
+void StdoutLoggerBuilder::SetAsDefaultLogger() noexcept
+{
+    const char* context_ptr{nullptr};
+    size_t context_size{0};
+    if (context_)
+    {
+        auto value{context_.value()};
+        context_ptr = value.c_str();
+        context_size = value.size();
+    }
+
+    const bool* show_module{show_module_ ? &show_module_.value() : nullptr};
+    const bool* show_file{show_file_ ? &show_file_.value() : nullptr};
+    const bool* show_line{show_line_ ? &show_line_.value() : nullptr};
+    const score::mw::log::rust::LogLevel* log_level{log_level_ ? &log_level_.value() : nullptr};
+
+    set_default_logger(context_ptr, context_size, show_module, show_file, show_line, log_level);
+}
+
+}  // namespace score::mw::log::rust

--- a/src/log/stdout_logger_cpp_init/stdout_logger_init.h
+++ b/src/log/stdout_logger_cpp_init/stdout_logger_init.h
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace score::mw::log::rust
+{
+
+/// @brief Represents severity of a log message.
+enum class LogLevel
+{
+    Off,
+    Fatal,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Verbose
+};
+
+/// @brief
+/// Builder for logger used by Rust libraries.
+///
+/// @note
+/// If parameter is not set explicitly then Rust-side default is used.
+/// Only global logger setup is allowed.
+class StdoutLoggerBuilder final
+{
+  public:
+    /// @brief Set context for the logger.
+    /// @param context
+    /// Context name.
+    /// @return This builder.
+    StdoutLoggerBuilder& Context(const std::string& context) noexcept;
+
+    /// @brief Show module name in logs.
+    /// @param show_module Value to set.
+    /// @return This builder.
+    StdoutLoggerBuilder& ShowModule(bool show_module) noexcept;
+
+    /// @brief Show file name in logs.
+    /// @param show_module Value to set.
+    /// @return This builder.
+    StdoutLoggerBuilder& ShowFile(bool show_file) noexcept;
+
+    /// @brief Show line number in logs.
+    /// @param show_module Value to set.
+    /// @return This builder.
+    StdoutLoggerBuilder& ShowLine(bool show_line) noexcept;
+
+    /// @brief Filter logs by level.
+    /// @param log_level Log level.
+    /// @return This builder.
+    StdoutLoggerBuilder& LogLevel(LogLevel log_level) noexcept;
+
+    /// @brief Initialize default logger with provided parameters.
+    void SetAsDefaultLogger() noexcept;
+
+  private:
+    std::optional<std::string> context_;
+    std::optional<bool> show_module_;
+    std::optional<bool> show_file_;
+    std::optional<bool> show_line_;
+    std::optional<score::mw::log::rust::LogLevel> log_level_;
+};
+
+}  // namespace score::mw::log::rust


### PR DESCRIPTION
- Add lib for log init when Rust lib is used by C++.
- Add example.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
