### PR TITLE
Make Heap<T> be Send for T:Send

### DIFF
--- a/src/containers/storage/heap.rs
+++ b/src/containers/storage/heap.rs
@@ -32,6 +32,9 @@ pub struct Heap<T> {
     _marker: PhantomData<T>,
 }
 
+// SAFETY: `Heap<T>` can be sent to another thread if `T` can be sent to another thread. It's because we use system allocation which is send-safe.
+unsafe impl<T: Send> Send for Heap<T> {}
+
 impl<T> Heap<T> {
     fn layout(capacity: u32) -> Option<Layout> {
         (capacity as usize)


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
