### PR TITLE
log: add timestamp to `stdout_logger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,18 +27,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/log/stdout_logger/timestamp.rs
+++ b/src/log/stdout_logger/timestamp.rs
@@ -1,0 +1,233 @@
+//
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Generate human-readable timestamp from Unix epoch time.
+//! Without allocations and external dependencies.
+//!
+//! WARNING: range checks are provided only for debug builds!
+
+use core::time::Duration;
+
+/// Determine if provided year is a leap year.
+fn is_leap_year(year: u64) -> bool {
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+/// Calculate time - hour, minute, second.
+/// `secs_in_day` must be less than number of seconds in a day.
+fn get_time(secs_in_day: u64) -> (u64, u64, u64) {
+    debug_assert!(secs_in_day < 24 * 60 * 60);
+
+    const SECS_PER_HOUR: u64 = 60 * 60;
+    let hour = secs_in_day / SECS_PER_HOUR;
+    let secs_in_day = secs_in_day % SECS_PER_HOUR;
+    let minute = secs_in_day / 60;
+    let second = secs_in_day % 60;
+
+    // Validate output.
+    debug_assert!(hour < 24);
+    debug_assert!(minute < 60);
+    debug_assert!(second < 60);
+
+    (hour, minute, second)
+}
+
+/// Calculate date - year, month, day.
+/// `days_in_epoch` must be less than number of days between:
+/// - 1970/01/01
+/// - 10000/01/01
+fn get_date(days_in_epoch: u64) -> (u64, u64, u64) {
+    debug_assert!(days_in_epoch <= 2932896);
+
+    // Local and mutable copy of `days_in_epoch`.
+    let mut days = days_in_epoch;
+
+    // Calculate year.
+    let mut year = 1970;
+    loop {
+        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    // Calculate month.
+    let days_in_feb = if is_leap_year(year) { 29 } else { 28 };
+    let days_in_month = [31, days_in_feb, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut month_index = 0;
+    while days >= days_in_month[month_index] {
+        days -= days_in_month[month_index];
+        month_index += 1;
+    }
+    let month = month_index as u64 + 1;
+
+    // Calculate day.
+    let day = days + 1;
+
+    // Validate output.
+    debug_assert!((1970..=9999).contains(&year));
+    debug_assert!((1..=12).contains(&month));
+    debug_assert!(day >= 1 && day <= days_in_month[month_index]);
+
+    (year, month, day)
+}
+
+/// Write integer value to `u8` slice as ASCII characters.
+fn write<const N: usize>(buf: &mut [u8], value: u64) {
+    for (i, v) in buf.iter_mut().enumerate() {
+        let digit = 10u64.pow((N - i - 1) as u32);
+        *v = b'0' + (value / digit % 10) as u8;
+    }
+}
+
+/// Get timestamp in following format:
+/// `[year]/[month]/[day] [hour]:[minute]:[second].[subsecond digits:7]`
+pub fn timestamp(duration_since_epoch_start: Duration) -> [u8; 27] {
+    debug_assert!(duration_since_epoch_start.as_secs() <= 253402300799);
+
+    let secs = duration_since_epoch_start.as_secs();
+    let subsec_nanos = duration_since_epoch_start.subsec_nanos() as u64;
+
+    const SECS_PER_DAY: u64 = 24 * 60 * 60;
+
+    // Calculate number of days since epoch and seconds in a day (remainder).
+    let days_in_epoch = secs / SECS_PER_DAY;
+    let secs_in_day = secs % SECS_PER_DAY;
+
+    // Calculate time.
+    let (hour, minute, second) = get_time(secs_in_day);
+
+    // Calculate date.
+    let (year, month, day) = get_date(days_in_epoch);
+
+    // Format output as `u8` array of known size.
+    let mut output = [0; _];
+
+    // Write date in `YYYY/MM/dd ` format.
+    write::<4>(&mut output[0..4], year);
+    output[4] = b'/';
+    write::<2>(&mut output[5..7], month);
+    output[7] = b'/';
+    write::<2>(&mut output[8..10], day);
+    output[10] = b' ';
+
+    // Write time in `HH:mm:ss.nnnnnnn` format.
+    write::<2>(&mut output[11..13], hour);
+    output[13] = b':';
+    write::<2>(&mut output[14..16], minute);
+    output[16] = b':';
+    write::<2>(&mut output[17..19], second);
+    output[19] = b'.';
+    write::<7>(&mut output[20..27], subsec_nanos / 100);
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_date, get_time, timestamp};
+    use core::time::Duration;
+
+    #[test]
+    fn test_get_time_zero() {
+        let (hour, minute, second) = get_time(0);
+        assert_eq!(hour, 0);
+        assert_eq!(minute, 0);
+        assert_eq!(second, 0);
+    }
+
+    #[test]
+    fn test_get_time_in_range() {
+        let (hour, minute, second) = get_time(45296);
+        assert_eq!(hour, 12);
+        assert_eq!(minute, 34);
+        assert_eq!(second, 56);
+    }
+
+    #[test]
+    fn test_get_time_max_allowed() {
+        let (hour, minute, second) = get_time(24 * 60 * 60 - 1);
+        assert_eq!(hour, 23);
+        assert_eq!(minute, 59);
+        assert_eq!(second, 59);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_time_out_of_range() {
+        let (_hour, _minute, _second) = get_time(24 * 60 * 60);
+    }
+
+    #[test]
+    fn test_get_date_zero() {
+        let (year, month, day) = get_date(0);
+        assert_eq!(year, 1970);
+        assert_eq!(month, 1);
+        assert_eq!(day, 1);
+    }
+
+    #[test]
+    fn test_get_date_in_range() {
+        let (year, month, day) = get_date(20481);
+        assert_eq!(year, 2026);
+        assert_eq!(month, 1);
+        assert_eq!(day, 28);
+    }
+
+    #[test]
+    fn test_get_date_max_allowed() {
+        let (year, month, day) = get_date(2932896);
+        assert_eq!(year, 9999);
+        assert_eq!(month, 12);
+        assert_eq!(day, 31);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_date_out_of_range() {
+        let (_hour, _minute, _second) = get_date(u64::MAX);
+    }
+
+    #[test]
+    fn test_timestamp_zero() {
+        let duration = Duration::from_secs(0);
+        let ts_u8 = timestamp(duration);
+        let ts_str = str::from_utf8(ts_u8.as_slice()).unwrap();
+        assert_eq!(ts_str, "1970/01/01 00:00:00.0000000");
+    }
+
+    #[test]
+    fn test_timestamp_in_range() {
+        let duration = Duration::from_secs(1769604017) + Duration::from_nanos(123456789);
+        let ts_u8 = timestamp(duration);
+        let ts_str = str::from_utf8(ts_u8.as_slice()).unwrap();
+        assert_eq!(ts_str, "2026/01/28 12:40:17.1234567");
+    }
+
+    #[test]
+    fn test_timestamp_max_allowed() {
+        let duration = Duration::from_secs(253402300799) + Duration::from_nanos(999999999);
+        let ts_u8 = timestamp(duration);
+        let ts_str = str::from_utf8(ts_u8.as_slice()).unwrap();
+        assert_eq!(ts_str, "9999/12/31 23:59:59.9999999");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_timestamp_out_of_range() {
+        let duration = Duration::from_secs(253402300800);
+        let _ = timestamp(duration);
+    }
+}

--- a/src/log/stdout_logger_cpp_init/ffi.rs
+++ b/src/log/stdout_logger_cpp_init/ffi.rs
@@ -50,6 +50,7 @@ extern "C" fn set_default_logger(
     show_module: *const bool,
     show_file: *const bool,
     show_line: *const bool,
+    show_timestamp: *const bool,
     log_level: *const LogLevel,
 ) {
     let mut builder = StdoutLoggerBuilder::new();
@@ -73,6 +74,10 @@ extern "C" fn set_default_logger(
 
     if !show_line.is_null() {
         builder = builder.show_line(unsafe { *show_line });
+    }
+
+    if !show_timestamp.is_null() {
+        builder = builder.show_timestamp(unsafe { *show_timestamp });
     }
 
     if !log_level.is_null() {

--- a/src/log/stdout_logger_cpp_init/stdout_logger_init.cpp
+++ b/src/log/stdout_logger_cpp_init/stdout_logger_init.cpp
@@ -18,6 +18,7 @@ extern "C" void set_default_logger(const char* context_ptr,
                                    const bool* show_module,
                                    const bool* show_file,
                                    const bool* show_line,
+                                   const bool* show_timestamp,
                                    const score::mw::log::rust::LogLevel* log_level);
 
 namespace score::mw::log::rust
@@ -47,6 +48,12 @@ StdoutLoggerBuilder& StdoutLoggerBuilder::ShowLine(bool show_line) noexcept
     return *this;
 }
 
+StdoutLoggerBuilder& StdoutLoggerBuilder::ShowTimestamp(bool show_timestamp) noexcept
+{
+    show_timestamp_ = show_timestamp;
+    return *this;
+}
+
 StdoutLoggerBuilder& StdoutLoggerBuilder::LogLevel(score::mw::log::rust::LogLevel log_level) noexcept
 {
     log_level_ = log_level;
@@ -67,9 +74,10 @@ void StdoutLoggerBuilder::SetAsDefaultLogger() noexcept
     const bool* show_module{show_module_ ? &show_module_.value() : nullptr};
     const bool* show_file{show_file_ ? &show_file_.value() : nullptr};
     const bool* show_line{show_line_ ? &show_line_.value() : nullptr};
+    const bool* show_timestamp{show_timestamp_ ? &show_timestamp_.value() : nullptr};
     const score::mw::log::rust::LogLevel* log_level{log_level_ ? &log_level_.value() : nullptr};
 
-    set_default_logger(context_ptr, context_size, show_module, show_file, show_line, log_level);
+    set_default_logger(context_ptr, context_size, show_module, show_file, show_line, show_timestamp, log_level);
 }
 
 }  // namespace score::mw::log::rust

--- a/src/log/stdout_logger_cpp_init/stdout_logger_init.h
+++ b/src/log/stdout_logger_cpp_init/stdout_logger_init.h
@@ -61,6 +61,16 @@ class StdoutLoggerBuilder final
     /// @return This builder.
     StdoutLoggerBuilder& ShowLine(bool show_line) noexcept;
 
+    /// @brief Show timestamp.
+    /// UTC timestamp in the following format:
+    /// `[year]/[month]/[day] [hour]:[minute]:[second].[subsecond digits:7]`
+    ///
+    /// Example:
+    /// `2026/01/27 11:33:41.1420089`
+    /// @param show_timestamp Value to set.
+    /// @return This builder.
+    StdoutLoggerBuilder& ShowTimestamp(bool show_timestamp) noexcept;
+
     /// @brief Filter logs by level.
     /// @param log_level Log level.
     /// @return This builder.
@@ -74,6 +84,7 @@ class StdoutLoggerBuilder final
     std::optional<bool> show_module_;
     std::optional<bool> show_file_;
     std::optional<bool> show_line_;
+    std::optional<bool> show_timestamp_;
     std::optional<score::mw::log::rust::LogLevel> log_level_;
 };
 


### PR DESCRIPTION
UTC timestamp to `stdout_logger`.
Show on default, parameter available.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #55 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
