### PR TITLE
Make logs belong to process

### DIFF
--- a/src/log/stdout_logger/lib.rs
+++ b/src/log/stdout_logger/lib.rs
@@ -314,7 +314,8 @@ impl Log for StdoutLogger {
             // Write context, log level, log data.
             let context = record.context();
             let level = metadata.level().as_str();
-            let _ = score_write!(writer, "[{}][{}] {}", context, level, record.args());
+            let pid = std::process::id();
+            let _ = score_write!(writer, "[{}][{}][{}] {}", pid, context, level, record.args());
 
             // Print to stdout.
             println!("{}", writer.get());


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
