### PR TITLE
Add "#![feature(non_null_from_ref)]" in log fmt lib.rs

### DIFF
--- a/src/log/score_log_fmt/lib.rs
+++ b/src/log/score_log_fmt/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! Replacement for [`core::fmt`].
 
+#![feature(non_null_from_ref)]
 mod builders;
 mod fmt;
 mod fmt_impl;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [X] Commits are properly organized
* [X] Relevant issues are linked in the [References](#references) section
* [X] Tests are conducted
* [ ] Unit tests are added **No new functionally is added**

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #61  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
