### PR TITLE
improvement: Implement ScoreDebug for u128, Duration and AddrParseError

### DIFF
--- a/examples/log_custom/src/logger.rs
+++ b/examples/log_custom/src/logger.rs
@@ -58,6 +58,10 @@ impl ScoreWrite for StringWriter {
         write!(self.buffer, "{}", v).map_err(|_| Error)
     }
 
+    fn write_i128(&mut self, v: &i128, _spec: &FormatSpec) -> FmtResult {
+        write!(self.buffer, "{}", v).map_err(|_| Error)
+    }
+
     fn write_u8(&mut self, v: &u8, _spec: &FormatSpec) -> FmtResult {
         write!(self.buffer, "{}", v).map_err(|_| Error)
     }
@@ -71,6 +75,10 @@ impl ScoreWrite for StringWriter {
     }
 
     fn write_u64(&mut self, v: &u64, _spec: &FormatSpec) -> FmtResult {
+        write!(self.buffer, "{}", v).map_err(|_| Error)
+    }
+
+    fn write_u128(&mut self, v: &u128, _spec: &FormatSpec) -> FmtResult {
         write!(self.buffer, "{}", v).map_err(|_| Error)
     }
 

--- a/src/log/score_log_fmt/fmt.rs
+++ b/src/log/score_log_fmt/fmt.rs
@@ -48,6 +48,8 @@ pub trait ScoreWrite {
     fn write_i32(&mut self, v: &i32, spec: &FormatSpec) -> Result;
     /// Write a `i64` into this writer.
     fn write_i64(&mut self, v: &i64, spec: &FormatSpec) -> Result;
+    /// Write a `i128` into this writer.
+    fn write_i128(&mut self, v: &i128, spec: &FormatSpec) -> Result;
     /// Write a `u8` into this writer.
     fn write_u8(&mut self, v: &u8, spec: &FormatSpec) -> Result;
     /// Write a `u16` into this writer.
@@ -56,6 +58,8 @@ pub trait ScoreWrite {
     fn write_u32(&mut self, v: &u32, spec: &FormatSpec) -> Result;
     /// Write a `u64` into this writer.
     fn write_u64(&mut self, v: &u64, spec: &FormatSpec) -> Result;
+    /// Write a `u128` into this writer.
+    fn write_u128(&mut self, v: &u128, spec: &FormatSpec) -> Result;
     /// Write a `&str` into this writer.
     fn write_str(&mut self, v: &str, spec: &FormatSpec) -> Result;
 }
@@ -154,10 +158,18 @@ mod tests {
             Fragment::Placeholder(Placeholder::new(&-1234i16, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&-123456i32, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&-1200000000000000000i64, FormatSpec::new())),
+            Fragment::Placeholder(Placeholder::new(
+                &-128000000000000000000000000000000000000i128,
+                FormatSpec::new(),
+            )),
             Fragment::Placeholder(Placeholder::new(&123u8, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&1234u16, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&123456u32, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&1200000000000000000u64, FormatSpec::new())),
+            Fragment::Placeholder(Placeholder::new(
+                &128000000000000000000000000000000000000u128,
+                FormatSpec::new(),
+            )),
             Fragment::Literal("_string"),
         ];
         let args = Arguments(&fragments);
@@ -165,7 +177,7 @@ mod tests {
         let result = ScoreDebug::fmt(&args, &mut w, &FormatSpec::new());
         assert!(result == Ok(()));
         assert!(
-            w.get() == "test_true123.4432.2-100-1234-123456-120000000000000000012312341234561200000000000000000_string"
+            w.get() == "test_true123.4432.2-100-1234-123456-1200000000000000000-12800000000000000000000000000000000000012312341234561200000000000000000128000000000000000000000000000000000000_string"
         )
     }
 
@@ -195,16 +207,24 @@ mod tests {
             Fragment::Placeholder(Placeholder::new(&-1234i16, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&-123456i32, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&-1200000000000000000i64, FormatSpec::new())),
+            Fragment::Placeholder(Placeholder::new(
+                &-128000000000000000000000000000000000000i128,
+                FormatSpec::new(),
+            )),
             Fragment::Placeholder(Placeholder::new(&123u8, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&1234u16, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&123456u32, FormatSpec::new())),
             Fragment::Placeholder(Placeholder::new(&1200000000000000000u64, FormatSpec::new())),
+            Fragment::Placeholder(Placeholder::new(
+                &128000000000000000000000000000000000000u128,
+                FormatSpec::new(),
+            )),
             Fragment::Placeholder(Placeholder::new(&"test", FormatSpec::new())),
         ];
         let args = Arguments(&fragments);
         assert!(write(&mut w, args) == Ok(()));
 
-        let exp_pattern = "true123.4432.2-100-1234-123456-120000000000000000012312341234561200000000000000000test";
+        let exp_pattern = "true123.4432.2-100-1234-123456-1200000000000000000-12800000000000000000000000000000000000012312341234561200000000000000000128000000000000000000000000000000000000test";
         assert_eq!(w.get(), exp_pattern);
     }
 

--- a/src/log/score_log_fmt/fmt_impl.rs
+++ b/src/log/score_log_fmt/fmt_impl.rs
@@ -35,10 +35,12 @@ impl_debug_for_t!(i8, write_i8);
 impl_debug_for_t!(i16, write_i16);
 impl_debug_for_t!(i32, write_i32);
 impl_debug_for_t!(i64, write_i64);
+impl_debug_for_t!(i128, write_i128);
 impl_debug_for_t!(u8, write_u8);
 impl_debug_for_t!(u16, write_u16);
 impl_debug_for_t!(u32, write_u32);
 impl_debug_for_t!(u64, write_u64);
+impl_debug_for_t!(u128, write_u128);
 
 impl ScoreDebug for () {
     fn fmt(&self, f: Writer, spec: &FormatSpec) -> Result {
@@ -83,6 +85,13 @@ impl ScoreDebug for std::string::FromUtf8Error {
             .field("bytes", &self.as_bytes())
             .field("error", &self.utf8_error())
             .finish()
+    }
+}
+
+impl ScoreDebug for core::time::Duration {
+    fn fmt(&self, f: Writer, spec: &FormatSpec) -> Result {
+        f.write_f64(&self.as_secs_f64(), spec)?;
+        f.write_str("s", spec)
     }
 }
 
@@ -273,6 +282,11 @@ mod tests {
     }
 
     #[test]
+    fn test_i128_debug() {
+        common_test_debug(-128000000000000000000000000000000000000i128);
+    }
+
+    #[test]
     fn test_u8_debug() {
         common_test_debug(123u8);
     }
@@ -290,6 +304,11 @@ mod tests {
     #[test]
     fn test_u64_debug() {
         common_test_debug(1200000000000000000u64);
+    }
+
+    #[test]
+    fn test_u128_debug() {
+        common_test_debug(128000000000000000000000000000000000000u128);
     }
 
     #[test]
@@ -374,6 +393,11 @@ mod tests {
     #[test]
     fn test_box_debug() {
         common_test_debug(Box::new(432.1));
+    }
+
+    #[test]
+    fn test_duration_debug() {
+        common_test_debug(core::time::Duration::new(123, 456789));
     }
 
     #[test]

--- a/src/log/score_log_fmt/fmt_impl_qm.rs
+++ b/src/log/score_log_fmt/fmt_impl_qm.rs
@@ -15,6 +15,7 @@
 
 use crate::fmt::{Result, ScoreDebug, Writer};
 use crate::fmt_spec::FormatSpec;
+use core::net::AddrParseError;
 use std::path::{Path, PathBuf};
 
 // TODO: replace with `core::char::MAX_LEN_UTF8` once stable.
@@ -51,6 +52,12 @@ impl ScoreDebug for PathBuf {
     }
 }
 
+impl ScoreDebug for AddrParseError {
+    fn fmt(&self, f: Writer, spec: &FormatSpec) -> Result {
+        f.write_str(&format!("{:?}", self), spec)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test_utils::common_test_debug;
@@ -64,5 +71,12 @@ mod tests {
     #[test]
     fn test_pathbuf_debug() {
         common_test_debug(PathBuf::from("/tmp/test_path"));
+    }
+
+    #[test]
+    fn test_addr_parse_error_debug() {
+        let a1 = "invalid address";
+        let a2: Result<std::net::IpAddr, std::net::AddrParseError> = a1.parse();
+        common_test_debug(a2.unwrap_err());
     }
 }

--- a/src/log/score_log_fmt/test_utils.rs
+++ b/src/log/score_log_fmt/test_utils.rs
@@ -65,6 +65,10 @@ impl ScoreWrite for StringWriter {
         Ok(write!(self.buf, "{}", v)?)
     }
 
+    fn write_i128(&mut self, v: &i128, _spec: &FormatSpec) -> Result {
+        Ok(write!(self.buf, "{}", v)?)
+    }
+
     fn write_u8(&mut self, v: &u8, _spec: &FormatSpec) -> Result {
         Ok(write!(self.buf, "{}", v)?)
     }
@@ -78,6 +82,10 @@ impl ScoreWrite for StringWriter {
     }
 
     fn write_u64(&mut self, v: &u64, _spec: &FormatSpec) -> Result {
+        Ok(write!(self.buf, "{}", v)?)
+    }
+
+    fn write_u128(&mut self, v: &u128, _spec: &FormatSpec) -> Result {
         Ok(write!(self.buf, "{}", v)?)
     }
 

--- a/src/log/score_log_fmt_macro/tests/utils/mod.rs
+++ b/src/log/score_log_fmt_macro/tests/utils/mod.rs
@@ -59,6 +59,10 @@ impl ScoreWrite for StringWriter {
         write!(self.buf, "{}", v).map_err(|_| Error)
     }
 
+    fn write_i128(&mut self, v: &i128, _spec: &FormatSpec) -> Result {
+        write!(self.buf, "{}", v).map_err(|_| Error)
+    }
+
     fn write_u8(&mut self, v: &u8, _spec: &FormatSpec) -> Result {
         write!(self.buf, "{}", v).map_err(|_| Error)
     }
@@ -72,6 +76,10 @@ impl ScoreWrite for StringWriter {
     }
 
     fn write_u64(&mut self, v: &u64, _spec: &FormatSpec) -> Result {
+        write!(self.buf, "{}", v).map_err(|_| Error)
+    }
+
+    fn write_u128(&mut self, v: &u128, _spec: &FormatSpec) -> Result {
         write!(self.buf, "{}", v).map_err(|_| Error)
     }
 

--- a/src/log/stdout_logger/lib.rs
+++ b/src/log/stdout_logger/lib.rs
@@ -141,6 +141,10 @@ impl<const N: usize> ScoreWrite for FixedBufWriter<N> {
         write!(self.buf, "{}", v).map_err(|_| Error)
     }
 
+    fn write_i128(&mut self, v: &i128, _spec: &FormatSpec) -> Result {
+        write!(self.buf, "{}", v).map_err(|_| Error)
+    }
+
     fn write_u8(&mut self, v: &u8, _spec: &FormatSpec) -> Result {
         write!(self.buf, "{}", v).map_err(|_| Error)
     }
@@ -154,6 +158,10 @@ impl<const N: usize> ScoreWrite for FixedBufWriter<N> {
     }
 
     fn write_u64(&mut self, v: &u64, _spec: &FormatSpec) -> Result {
+        write!(self.buf, "{}", v).map_err(|_| Error)
+    }
+
+    fn write_u128(&mut self, v: &u128, _spec: &FormatSpec) -> Result {
         write!(self.buf, "{}", v).map_err(|_| Error)
     }
 


### PR DESCRIPTION
Implemented ScoreDebug for u128, i128, core::time::Duration and core::net::parser::AddrParseError (QM).

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [x] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #74  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
