### PR TITLE
alloc: allow `containers` to use custom allocators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,9 @@ version = 4
 [[package]]
 name = "containers"
 version = "0.1.0"
+dependencies = [
+ "elementary",
+]
 
 [[package]]
 name = "elementary"

--- a/src/containers/BUILD
+++ b/src/containers/BUILD
@@ -18,6 +18,7 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     edition = "2021",
     visibility = ["//visibility:public"],
+    deps = ["//src/elementary"],
 )
 
 rust_test(

--- a/src/containers/Cargo.toml
+++ b/src/containers/Cargo.toml
@@ -21,3 +21,6 @@ license-file = "../../LICENSE.md"
 
 [lib]
 path = "lib.rs"
+
+[dependencies]
+elementary.workspace = true

--- a/src/containers/fixed_capacity/mod.rs
+++ b/src/containers/fixed_capacity/mod.rs
@@ -15,6 +15,6 @@ mod queue;
 mod string;
 mod vec;
 
-pub use self::queue::FixedCapacityQueue;
-pub use self::string::FixedCapacityString;
-pub use self::vec::FixedCapacityVec;
+pub use self::queue::{FixedCapacityQueue, FixedCapacityQueueIn};
+pub use self::string::{FixedCapacityString, FixedCapacityStringIn};
+pub use self::vec::{FixedCapacityVec, FixedCapacityVecIn};

--- a/src/containers/fixed_capacity/queue.rs
+++ b/src/containers/fixed_capacity/queue.rs
@@ -11,18 +11,62 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
-use core::ops;
-
 use crate::generic::queue::GenericQueue;
 use crate::storage::Heap;
+use core::ops;
+use elementary::{BasicAllocator, HeapAllocator, GLOBAL_ALLOCATOR};
 
-/// A fixed-capacity queue.
+/// A fixed-capacity queue, using provided allocator.
 ///
 /// The queue can hold between 0 and `CAPACITY` elements, and behaves similarly to Rust's `VecDeque`,
 /// except that it allocates memory immediately on construction, and can't shrink or grow.
-pub struct FixedCapacityQueue<T> {
-    inner: GenericQueue<T, Heap<T>>,
+pub struct FixedCapacityQueueIn<'alloc, T, A: BasicAllocator> {
+    inner: GenericQueue<T, Heap<'alloc, T, A>>,
 }
+
+impl<'alloc, T, A: BasicAllocator> FixedCapacityQueueIn<'alloc, T, A> {
+    /// Creates an empty queue and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `capacity > u32::MAX`.
+    /// - Panics if the memory allocation fails.
+    #[must_use]
+    pub fn new(capacity: usize, alloc: &'alloc A) -> Self {
+        assert!(
+            capacity <= u32::MAX as usize,
+            "FixedQueue can hold at most u32::MAX elements"
+        );
+
+        let storage = Heap::new(capacity as u32, alloc);
+        let inner = GenericQueue::new(storage);
+        Self { inner }
+    }
+}
+
+impl<T, A: BasicAllocator> Drop for FixedCapacityQueueIn<'_, T, A> {
+    fn drop(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl<'alloc, T, A: BasicAllocator> ops::Deref for FixedCapacityQueueIn<'alloc, T, A> {
+    type Target = GenericQueue<T, Heap<'alloc, T, A>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T, A: BasicAllocator> ops::DerefMut for FixedCapacityQueueIn<'_, T, A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// A fixed-capacity queue, using global allocator.
+/// Refer to [`FixedCapacityQueueIn`] for more information.
+pub struct FixedCapacityQueue<T>(FixedCapacityQueueIn<'static, T, HeapAllocator>);
 
 impl<T> FixedCapacityQueue<T> {
     /// Creates an empty queue and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
@@ -33,41 +77,28 @@ impl<T> FixedCapacityQueue<T> {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        assert!(
-            capacity <= u32::MAX as usize,
-            "FixedQueue can hold at most u32::MAX elements"
-        );
-        Self {
-            inner: GenericQueue::new(capacity as u32),
-        }
-    }
-}
-
-impl<T> Drop for FixedCapacityQueue<T> {
-    fn drop(&mut self) {
-        self.inner.clear();
+        Self(FixedCapacityQueueIn::new(capacity, &GLOBAL_ALLOCATOR))
     }
 }
 
 impl<T> ops::Deref for FixedCapacityQueue<T> {
-    type Target = GenericQueue<T, Heap<T>>;
+    type Target = GenericQueue<T, Heap<'static, T, HeapAllocator>>;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.0.inner
     }
 }
 
 impl<T> ops::DerefMut for FixedCapacityQueue<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+        &mut self.0.inner
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
-
     use super::*;
+    use std::collections::VecDeque;
 
     fn to_vec<T: Copy>((first, second): (&[T], &[T])) -> Vec<T> {
         let mut elements = first.to_vec();

--- a/src/containers/fixed_capacity/string.rs
+++ b/src/containers/fixed_capacity/string.rs
@@ -11,21 +11,96 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
-use core::fmt;
-use core::ops;
-
 use crate::generic::string::GenericString;
 use crate::storage::Heap;
+use core::fmt;
+use core::ops;
+use elementary::GLOBAL_ALLOCATOR;
+use elementary::{BasicAllocator, HeapAllocator};
 
-/// A fixed-capacity Unicode string.
+/// A fixed-capacity Unicode string, using provided allocator..
 ///
 /// Note that the string is encoded as UTF-8, so each character (Unicode codepoint) requires between 1 and 4 bytes of storage.
 ///
 /// The string can hold between 0 and `CAPACITY` **bytes**, and behaves similarly to Rust's `String`,
 /// except that it allocates memory immediately on construction, and can't shrink or grow.
-pub struct FixedCapacityString {
-    inner: GenericString<Heap<u8>>,
+pub struct FixedCapacityStringIn<'alloc, A: BasicAllocator> {
+    inner: GenericString<Heap<'alloc, u8, A>>,
 }
+
+impl<'alloc, A: BasicAllocator> FixedCapacityStringIn<'alloc, A> {
+    /// Creates an empty string and allocates memory for up to `capacity` bytes, where `capacity <= u32::MAX`.
+    ///
+    /// Note that the string is encoded as UTF-8, so each character (Unicode codepoint) requires between 1 and 4 bytes of storage.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `capacity > u32::MAX`.
+    /// - Panics if the memory allocation fails.
+    #[must_use]
+    pub fn new(capacity: usize, alloc: &'alloc A) -> Self {
+        assert!(
+            capacity <= u32::MAX as usize,
+            "FixedCapacityString can hold at most u32::MAX bytes"
+        );
+
+        let storage = Heap::new(capacity as u32, alloc);
+        let inner = GenericString::new(storage);
+        Self { inner }
+    }
+
+    /// Tries to create an empty string for up to `capacity` bytes, where `capacity <= u32::MAX`.
+    ///
+    /// Note that the string is encoded as UTF-8, so each character (Unicode codepoint) requires between 1 and 4 bytes of storage.
+    ///
+    /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
+    #[must_use]
+    pub fn try_new(capacity: usize, alloc: &'alloc A) -> Option<Self> {
+        if capacity <= u32::MAX as usize {
+            let storage = Heap::try_new(capacity as u32, alloc)?;
+            let inner = GenericString::new(storage);
+            Some(Self { inner })
+        } else {
+            None
+        }
+    }
+}
+
+impl<A: BasicAllocator> Drop for FixedCapacityStringIn<'_, A> {
+    fn drop(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl<'alloc, A: BasicAllocator> ops::Deref for FixedCapacityStringIn<'alloc, A> {
+    type Target = GenericString<Heap<'alloc, u8, A>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<A: BasicAllocator> ops::DerefMut for FixedCapacityStringIn<'_, A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<A: BasicAllocator> fmt::Display for FixedCapacityStringIn<'_, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+impl<A: BasicAllocator> fmt::Debug for FixedCapacityStringIn<'_, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+/// A fixed-capacity Unicode string, using global allocator.
+/// Refer to [`FixedCapacityStringIn`] for more information.
+pub struct FixedCapacityString(FixedCapacityStringIn<'static, HeapAllocator>);
 
 impl FixedCapacityString {
     /// Creates an empty string and allocates memory for up to `capacity` bytes, where `capacity <= u32::MAX`.
@@ -38,13 +113,7 @@ impl FixedCapacityString {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        assert!(
-            capacity <= u32::MAX as usize,
-            "FixedCapacityString can hold at most u32::MAX bytes"
-        );
-        Self {
-            inner: GenericString::new(capacity as u32),
-        }
+        Self(FixedCapacityStringIn::new(capacity, &GLOBAL_ALLOCATOR))
     }
 
     /// Tries to create an empty string for up to `capacity` bytes, where `capacity <= u32::MAX`.
@@ -54,45 +123,34 @@ impl FixedCapacityString {
     /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
     #[must_use]
     pub fn try_new(capacity: usize) -> Option<Self> {
-        if capacity <= u32::MAX as usize {
-            Some(Self {
-                inner: GenericString::try_new(capacity as u32)?,
-            })
-        } else {
-            None
-        }
-    }
-}
-
-impl Drop for FixedCapacityString {
-    fn drop(&mut self) {
-        self.inner.clear();
+        let inner = FixedCapacityStringIn::try_new(capacity, &GLOBAL_ALLOCATOR)?;
+        Some(Self(inner))
     }
 }
 
 impl ops::Deref for FixedCapacityString {
-    type Target = GenericString<Heap<u8>>;
+    type Target = GenericString<Heap<'static, u8, HeapAllocator>>;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.0.inner
     }
 }
 
 impl ops::DerefMut for FixedCapacityString {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+        &mut self.0.inner
     }
 }
 
 impl fmt::Display for FixedCapacityString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self.as_str(), f)
+        fmt::Display::fmt(self.0.as_str(), f)
     }
 }
 
 impl fmt::Debug for FixedCapacityString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self.as_str(), f)
+        fmt::Debug::fmt(self.0.as_str(), f)
     }
 }
 

--- a/src/containers/fixed_capacity/vec.rs
+++ b/src/containers/fixed_capacity/vec.rs
@@ -11,19 +11,83 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
-use core::fmt;
-use core::ops;
-
 use crate::generic::vec::GenericVec;
 use crate::storage::Heap;
+use core::fmt;
+use core::ops;
+use elementary::{BasicAllocator, HeapAllocator, GLOBAL_ALLOCATOR};
 
-/// A fixed-capacity vector.
+/// A fixed-capacity vector, using provided allocator.
 ///
-/// The vector can hold between 0 and `CAPACITY` elements, and behaves similarly to Rust's `Vec`,
+/// The vector can hold between 0 and `capacity` elements, and behaves similarly to Rust's `Vec`,
 /// except that it allocates memory immediately on construction, and can't shrink or grow.
-pub struct FixedCapacityVec<T> {
-    inner: GenericVec<T, Heap<T>>,
+pub struct FixedCapacityVecIn<'alloc, T, A: BasicAllocator> {
+    inner: GenericVec<T, Heap<'alloc, T, A>>,
 }
+
+impl<'alloc, T, A: BasicAllocator> FixedCapacityVecIn<'alloc, T, A> {
+    /// Creates an empty vector and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `capacity > u32::MAX`.
+    /// - Panics if the memory allocation fails.
+    #[must_use]
+    pub fn new(capacity: usize, alloc: &'alloc A) -> Self {
+        assert!(
+            capacity <= u32::MAX as usize,
+            "FixedCapacityVec can hold at most u32::MAX elements"
+        );
+
+        let storage = Heap::new(capacity as u32, alloc);
+        let inner = GenericVec::new(storage);
+        Self { inner }
+    }
+
+    /// Tries to create an empty vector for up to `capacity` elements, where `capacity <= u32::MAX`.
+    ///
+    /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
+    #[must_use]
+    pub fn try_new(capacity: usize, alloc: &'alloc A) -> Option<Self> {
+        if capacity <= u32::MAX as usize {
+            let storage = Heap::try_new(capacity as u32, alloc)?;
+            let inner = GenericVec::new(storage);
+            Some(Self { inner })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, A: BasicAllocator> Drop for FixedCapacityVecIn<'_, T, A> {
+    fn drop(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl<'alloc, T, A: BasicAllocator> ops::Deref for FixedCapacityVecIn<'alloc, T, A> {
+    type Target = GenericVec<T, Heap<'alloc, T, A>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T, A: BasicAllocator> ops::DerefMut for FixedCapacityVecIn<'_, T, A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T: fmt::Debug, A: BasicAllocator> fmt::Debug for FixedCapacityVecIn<'_, T, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_slice(), f)
+    }
+}
+
+/// A fixed-capacity vector, using global allocator.
+/// Refer to [`FixedCapacityVecIn`] for more information.
+pub struct FixedCapacityVec<T>(FixedCapacityVecIn<'static, T, HeapAllocator>);
 
 impl<T> FixedCapacityVec<T> {
     /// Creates an empty vector and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
@@ -34,13 +98,7 @@ impl<T> FixedCapacityVec<T> {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        assert!(
-            capacity <= u32::MAX as usize,
-            "FixedCapacityVec can hold at most u32::MAX elements"
-        );
-        Self {
-            inner: GenericVec::new(capacity as u32),
-        }
+        Self(FixedCapacityVecIn::new(capacity, &GLOBAL_ALLOCATOR))
     }
 
     /// Tries to create an empty vector for up to `capacity` elements, where `capacity <= u32::MAX`.
@@ -48,39 +106,28 @@ impl<T> FixedCapacityVec<T> {
     /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
     #[must_use]
     pub fn try_new(capacity: usize) -> Option<Self> {
-        if capacity <= u32::MAX as usize {
-            Some(Self {
-                inner: GenericVec::try_new(capacity as u32)?,
-            })
-        } else {
-            None
-        }
-    }
-}
-
-impl<T> Drop for FixedCapacityVec<T> {
-    fn drop(&mut self) {
-        self.inner.clear();
+        let inner = FixedCapacityVecIn::try_new(capacity, &GLOBAL_ALLOCATOR)?;
+        Some(Self(inner))
     }
 }
 
 impl<T> ops::Deref for FixedCapacityVec<T> {
-    type Target = GenericVec<T, Heap<T>>;
+    type Target = GenericVec<T, Heap<'static, T, HeapAllocator>>;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.0.inner
     }
 }
 
 impl<T> ops::DerefMut for FixedCapacityVec<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+        &mut self.0.inner
     }
 }
 
 impl<T: fmt::Debug> fmt::Debug for FixedCapacityVec<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self.as_slice(), f)
+        fmt::Debug::fmt(self.0.as_slice(), f)
     }
 }
 

--- a/src/containers/generic/queue.rs
+++ b/src/containers/generic/queue.rs
@@ -33,12 +33,12 @@ pub struct GenericQueue<T, S: Storage<T>> {
 }
 
 impl<T, S: Storage<T>> GenericQueue<T, S> {
-    /// Creates an empty queue.
-    pub fn new(capacity: u32) -> Self {
+    /// Creates an empty queue backed by the given storage.
+    pub fn new(storage: S) -> Self {
         Self {
             len: 0,
             front_index: 0,
-            storage: S::new(capacity),
+            storage,
             _marker: PhantomData,
         }
     }
@@ -382,9 +382,9 @@ impl<T> FusedIterator for IterMut<'_, T> {}
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, mem::MaybeUninit};
-
     use super::*;
+    use crate::storage::test_utils::TestVec;
+    use std::collections::VecDeque;
 
     fn to_vec<T: Copy>((first, second): (&[T], &[T])) -> Vec<T> {
         let mut elements = first.to_vec();
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn front_and_back() {
-        fn check_front_and_back(queue: &mut GenericQueue<i64, Vec<MaybeUninit<i64>>>, control: &mut VecDeque<i64>) {
+        fn check_front_and_back(queue: &mut GenericQueue<i64, TestVec<i64>>, control: &mut VecDeque<i64>) {
             assert_eq!(queue.front(), control.front());
             assert_eq!(queue.front_mut(), control.front_mut());
             assert_eq!(queue.back(), control.back());
@@ -402,7 +402,8 @@ mod tests {
         }
 
         fn run_test(n: usize) {
-            let mut queue = GenericQueue::<i64, Vec<MaybeUninit<i64>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut queue = GenericQueue::new(storage);
             let mut control = VecDeque::new();
 
             // Completely fill and empty the queue n times, but move the internal start point
@@ -437,7 +438,7 @@ mod tests {
 
     #[test]
     fn iter() {
-        fn check_iter(queue: &mut GenericQueue<i64, Vec<MaybeUninit<i64>>>, control: &mut VecDeque<i64>) {
+        fn check_iter(queue: &mut GenericQueue<i64, TestVec<i64>>, control: &mut VecDeque<i64>) {
             // Test the Iterator::next() implementation:
             assert_eq!(queue.iter().collect::<Vec<_>>(), control.iter().collect::<Vec<_>>());
             assert_eq!(
@@ -456,7 +457,8 @@ mod tests {
         }
 
         fn run_test(n: usize) {
-            let mut queue = GenericQueue::<i64, Vec<MaybeUninit<i64>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut queue = GenericQueue::new(storage);
             let mut control = VecDeque::new();
 
             // Completely fill and empty the queue n times, but move the internal start point
@@ -492,7 +494,8 @@ mod tests {
     #[test]
     fn push_back_and_pop_front() {
         fn run_test(n: usize) {
-            let mut queue = GenericQueue::<i64, Vec<MaybeUninit<i64>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut queue = GenericQueue::new(storage);
             let mut control = VecDeque::new();
 
             // Completely fill and empty the queue n times, but move the internal start point
@@ -535,7 +538,8 @@ mod tests {
     #[test]
     fn push_front_and_pop_back() {
         fn run_test(n: usize) {
-            let mut queue = GenericQueue::<i64, Vec<MaybeUninit<i64>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut queue = GenericQueue::new(storage);
             let mut control = VecDeque::new();
 
             // Completely fill and empty the queue n times, but move the internal start point
@@ -578,7 +582,8 @@ mod tests {
     #[test]
     fn is_empty_and_is_full() {
         fn run_test(n: usize) {
-            let mut queue = GenericQueue::<i64, Vec<MaybeUninit<i64>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut queue = GenericQueue::new(storage);
 
             // Completely fill and empty the queue n times, but move the internal start point
             // ahead by one each time

--- a/src/containers/generic/string.rs
+++ b/src/containers/generic/string.rs
@@ -27,28 +27,13 @@ pub struct GenericString<S: Storage<u8>> {
 }
 
 impl<S: Storage<u8>> GenericString<S> {
-    /// Creates an empty string with the given capacity in bytes.
+    /// Creates an empty string backed by the given storage.
     ///
     /// Note that the string is encoded as UTF-8, so each character (Unicode codepoint) requires between 1 and 4 bytes of storage.
-    ///
-    /// # Panics
-    ///
-    /// Panics if not enough memory could be allocated.
-    pub fn new(capacity: u32) -> Self {
+    pub fn new(storage: S) -> Self {
         Self {
-            vec: GenericVec::new(capacity),
+            vec: GenericVec::new(storage),
         }
-    }
-
-    /// Tries to create an empty string with the given capacity in bytes.
-    ///
-    /// Note that the string is encoded as UTF-8, so each character (Unicode codepoint) requires between 1 and 4 bytes of storage.
-    ///
-    /// Returns `None` if not enough memory could be allocated.
-    pub fn try_new(capacity: u32) -> Option<Self> {
-        Some(Self {
-            vec: GenericVec::try_new(capacity)?,
-        })
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -154,14 +139,14 @@ impl<S: Storage<u8>> fmt::Debug for GenericString<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::MaybeUninit;
-
     use super::*;
+    use crate::storage::test_utils::TestVec;
 
     #[test]
     fn push_and_pop() {
         fn run_test(n: usize) {
-            let mut string = GenericString::<Vec<MaybeUninit<u8>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut string = GenericString::new(storage);
             let mut control = String::new();
 
             let result = string.pop();
@@ -196,7 +181,8 @@ mod tests {
     #[test]
     fn push_str() {
         fn run_test(n: usize) {
-            let mut string = GenericString::<Vec<MaybeUninit<u8>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut string = GenericString::new(storage);
             let mut control = String::new();
 
             let samples = ["abc", "\0", "😉", "👍🏼🚀", "αβγ"];
@@ -224,7 +210,8 @@ mod tests {
     #[test]
     fn is_full_and_is_empty() {
         fn run_test(n: usize) {
-            let mut string = GenericString::<Vec<MaybeUninit<u8>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut string = GenericString::new(storage);
             assert!(string.is_empty());
 
             let sample = "abcdefghi";

--- a/src/containers/generic/vec.rs
+++ b/src/containers/generic/vec.rs
@@ -28,28 +28,13 @@ pub struct GenericVec<T, S: Storage<T>> {
 }
 
 impl<T, S: Storage<T>> GenericVec<T, S> {
-    /// Creates an empty vector with the given capacity.
-    ///
-    /// # Panics
-    ///
-    /// Panics if not enough memory could be allocated.
-    pub fn new(capacity: u32) -> Self {
+    /// Creates an empty vector backed by the given storage.
+    pub fn new(storage: S) -> Self {
         Self {
             len: 0,
-            storage: S::new(capacity),
+            storage,
             _marker: PhantomData,
         }
-    }
-
-    /// Tries to create an empty vector with the given capacity.
-    ///
-    /// Returns `None` if not enough memory could be allocated.
-    pub fn try_new(capacity: u32) -> Option<Self> {
-        Some(Self {
-            len: 0,
-            storage: S::try_new(capacity)?,
-            _marker: PhantomData,
-        })
     }
 
     /// Extracts a slice containing the entire vector.
@@ -192,14 +177,14 @@ impl<T: fmt::Debug, S: Storage<T>> fmt::Debug for GenericVec<T, S> {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::MaybeUninit;
-
     use super::*;
+    use crate::storage::test_utils::TestVec;
 
     #[test]
     fn push_and_pop() {
         fn run_test(n: usize) {
-            let mut vector = GenericVec::<i64, Vec<MaybeUninit<i64>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut vector = GenericVec::new(storage);
             let mut control = vec![];
 
             let result = vector.pop();
@@ -234,7 +219,8 @@ mod tests {
     #[test]
     fn is_full_and_is_empty() {
         fn run_test(n: usize) {
-            let mut vector = GenericVec::<i64, Vec<MaybeUninit<i64>>>::new(n as u32);
+            let storage = TestVec::new(n);
+            let mut vector = GenericVec::new(storage);
             assert!(vector.is_empty());
 
             for i in 0..n {

--- a/src/containers/inline/queue.rs
+++ b/src/containers/inline/queue.rs
@@ -47,9 +47,9 @@ impl<T: Copy, const CAPACITY: usize> InlineQueue<T, CAPACITY> {
     pub fn new() -> Self {
         let () = Self::CHECK_CAPACITY;
 
-        Self {
-            inner: GenericQueue::new(CAPACITY as u32),
-        }
+        let storage = Inline::<T, CAPACITY>::new();
+        let inner = GenericQueue::new(storage);
+        Self { inner }
     }
 }
 

--- a/src/containers/inline/string.rs
+++ b/src/containers/inline/string.rs
@@ -45,12 +45,13 @@ impl<const CAPACITY: usize> InlineString<CAPACITY> {
     const CHECK_CAPACITY: () = assert!(0 < CAPACITY && CAPACITY <= u32::MAX as usize);
 
     /// Creates an empty string.
+    #[must_use]
     pub fn new() -> Self {
         let () = Self::CHECK_CAPACITY;
 
-        Self {
-            inner: GenericString::new(CAPACITY as u32),
-        }
+        let storage = Inline::<_, CAPACITY>::new();
+        let inner = GenericString::new(storage);
+        Self { inner }
     }
 }
 

--- a/src/containers/inline/vec.rs
+++ b/src/containers/inline/vec.rs
@@ -43,12 +43,13 @@ impl<T: Copy, const CAPACITY: usize> InlineVec<T, CAPACITY> {
     const CHECK_CAPACITY: () = assert!(0 < CAPACITY && CAPACITY <= u32::MAX as usize);
 
     /// Creates an empty vector.
+    #[must_use]
     pub fn new() -> Self {
         let () = Self::CHECK_CAPACITY;
 
-        Self {
-            inner: GenericVec::new(CAPACITY as u32),
-        }
+        let storage = Inline::<T, CAPACITY>::new();
+        let inner = GenericVec::new(storage);
+        Self { inner }
     }
 }
 

--- a/src/containers/storage/heap.rs
+++ b/src/containers/storage/heap.rs
@@ -11,31 +11,31 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
-use alloc::alloc::alloc;
-use alloc::alloc::dealloc;
+use crate::storage::Storage;
 use alloc::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ptr;
 use core::ptr::NonNull;
-
-use super::Storage;
+use elementary::BasicAllocator;
 
 /// Fixed-capacity, heap-allocated storage.
-pub struct Heap<T> {
+pub struct Heap<'alloc, T, A: BasicAllocator> {
     /// Allocated capacity, in number of elements.
     capacity: u32,
     /// Pointer to the allocated memory.
     ///
     /// If `self.capacity > 0`, this points to an allocated memory area of size `self.capacity * size_of<T>` and alignment `align_of<T>`.
     elements: NonNull<T>,
+    /// Allocator used by the storage.
+    alloc: &'alloc A,
     _marker: PhantomData<T>,
 }
 
-// SAFETY: `Heap<T>` can be sent to another thread if `T` can be sent to another thread. It's because we use system allocation which is send-safe.
-unsafe impl<T: Send> Send for Heap<T> {}
+// SAFETY: `Heap<T>` can be sent to another thread if `T` can be sent to another thread and used allocator is send-safe.
+unsafe impl<T: Send, A: BasicAllocator + Send> Send for Heap<'_, T, A> {}
 
-impl<T> Heap<T> {
+impl<T, A: BasicAllocator> Heap<'_, T, A> {
     fn layout(capacity: u32) -> Option<Layout> {
         (capacity as usize)
             .checked_mul(size_of::<T>())
@@ -43,14 +43,14 @@ impl<T> Heap<T> {
     }
 }
 
-impl<T> Storage<T> for Heap<T> {
+impl<'alloc, T, A: BasicAllocator> Heap<'alloc, T, A> {
     /// Creates a new instance with capacity for exactly the given number of elements.
     ///
     /// # Panics
     ///
     /// Panics if the memory allocation failed.
-    fn new(capacity: u32) -> Self {
-        Self::try_new(capacity).unwrap_or_else(|| {
+    pub fn new(capacity: u32, alloc: &'alloc A) -> Self {
+        Self::try_new(capacity, alloc).unwrap_or_else(|| {
             panic!(
                 "failed to allocate {capacity} elements of {typ}",
                 typ = core::any::type_name::<T>()
@@ -61,21 +61,24 @@ impl<T> Storage<T> for Heap<T> {
     /// Tries to create a new instance with capacity for exactly the given number of elements.
     ///
     /// Returns `None` if the memory allocation failed.
-    fn try_new(capacity: u32) -> Option<Self> {
+    pub fn try_new(capacity: u32, alloc: &'alloc A) -> Option<Self> {
         let storage = if capacity > 0 {
             let layout = Self::layout(capacity)?;
             // SAFETY: `layout` has a non-zero size (because `capacity` is > 0)
-            NonNull::new(unsafe { alloc(layout) })?
+            NonNull::new(alloc.allocate(layout).ok()?.as_ptr())?
         } else {
             NonNull::dangling()
         };
         Some(Self {
             capacity,
             elements: storage.cast::<T>(),
+            alloc,
             _marker: PhantomData,
         })
     }
+}
 
+impl<T, A: BasicAllocator> Storage<T> for Heap<'_, T, A> {
     fn capacity(&self) -> u32 {
         self.capacity
     }
@@ -119,7 +122,7 @@ impl<T> Storage<T> for Heap<T> {
     }
 }
 
-impl<T> Drop for Heap<T> {
+impl<T, A: BasicAllocator> Drop for Heap<'_, T, A> {
     fn drop(&mut self) {
         if self.capacity > 0 {
             let layout = Self::layout(self.capacity).unwrap();
@@ -127,7 +130,8 @@ impl<T> Drop for Heap<T> {
             // - `self.elements` has previously been allocated with `alloc`
             // - `layout` is the same as the one used for the allocation
             unsafe {
-                dealloc(self.elements.as_ptr().cast::<u8>(), layout);
+                let ptr = self.elements.cast();
+                self.alloc.deallocate(ptr, layout);
             }
         }
     }
@@ -136,13 +140,14 @@ impl<T> Drop for Heap<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use elementary::{HeapAllocator, GLOBAL_ALLOCATOR};
 
     #[test]
     fn subslice() {
         type T = u64;
 
         fn run_test(capacity: u32) {
-            let instance = Heap::<T>::new(capacity);
+            let instance = Heap::<T, _>::new(capacity, &GLOBAL_ALLOCATOR);
 
             let empty_slice = unsafe { instance.subslice(0, 0) };
             assert_eq!(empty_slice.len(), 0);
@@ -176,7 +181,7 @@ mod tests {
         type T = u64;
 
         fn run_test(capacity: u32) {
-            let mut instance = Heap::<T>::new(capacity);
+            let mut instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
 
             let empty_slice = unsafe { instance.subslice_mut(0, 0) };
             assert_eq!(empty_slice.len(), 0);
@@ -210,7 +215,7 @@ mod tests {
         type T = u64;
 
         fn run_test(capacity: u32) {
-            let instance = Heap::<T>::new(capacity);
+            let instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
 
             if capacity >= 1 {
                 let first_element = unsafe { instance.element(0) };
@@ -245,7 +250,7 @@ mod tests {
         type T = u64;
 
         fn run_test(capacity: u32) {
-            let mut instance = Heap::<T>::new(capacity);
+            let mut instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
 
             if capacity >= 1 {
                 let first_element = unsafe { instance.element_mut(0) };

--- a/src/containers/storage/inline.rs
+++ b/src/containers/storage/inline.rs
@@ -28,38 +28,24 @@ impl<T, const CAPACITY: usize> Inline<T, CAPACITY> {
     // Compile-time check. This condition _must_ be referenced in every function that depends on it,
     // otherwise it will be removed during monomorphization.
     const CHECK_CAPACITY: () = assert!(0 < CAPACITY && CAPACITY <= (u32::MAX as usize));
-}
 
-impl<T, const CAPACITY: usize> Storage<T> for Inline<T, CAPACITY> {
     /// Creates a new instance.
-    ///
-    /// # Panics
-    ///
-    /// Panics if and only if `capacity != CAPACITY`.
-    fn new(capacity: u32) -> Self {
+    pub fn new() -> Self {
         let () = Self::CHECK_CAPACITY;
 
-        assert_eq!(capacity as usize, CAPACITY);
         Self {
             elements: [const { MaybeUninit::uninit() }; CAPACITY],
         }
     }
+}
 
-    /// Tries to create a new instance.
-    ///
-    /// Returns `None` if and only if `capacity != CAPACITY`.
-    fn try_new(capacity: u32) -> Option<Self> {
-        let () = Self::CHECK_CAPACITY;
-
-        if capacity as usize == CAPACITY {
-            Some(Self {
-                elements: [const { MaybeUninit::uninit() }; CAPACITY],
-            })
-        } else {
-            None
-        }
+impl<T, const CAPACITY: usize> Default for Inline<T, CAPACITY> {
+    fn default() -> Self {
+        Self::new()
     }
+}
 
+impl<T, const CAPACITY: usize> Storage<T> for Inline<T, CAPACITY> {
     fn capacity(&self) -> u32 {
         let () = Self::CHECK_CAPACITY;
 
@@ -119,7 +105,7 @@ mod tests {
 
         fn run_test<const N: usize>() {
             let capacity = N as u32;
-            let instance = Inline::<T, N>::new(capacity);
+            let instance = Inline::<T, N>::new();
 
             let empty_slice = unsafe { instance.subslice(0, 0) };
             assert_eq!(empty_slice.len(), 0);
@@ -159,7 +145,7 @@ mod tests {
 
         fn run_test<const N: usize>() {
             let capacity = N as u32;
-            let mut instance = Inline::<T, N>::new(capacity);
+            let mut instance = Inline::<T, N>::new();
 
             let empty_slice = unsafe { instance.subslice_mut(0, 0) };
             assert_eq!(empty_slice.len(), 0);
@@ -199,7 +185,7 @@ mod tests {
 
         fn run_test<const N: usize>() {
             let capacity = N as u32;
-            let instance = Inline::<T, N>::new(capacity);
+            let instance = Inline::<T, N>::new();
 
             if capacity >= 1 {
                 let first_element = unsafe { instance.element(0) };
@@ -240,7 +226,7 @@ mod tests {
 
         fn run_test<const N: usize>() {
             let capacity = N as u32;
-            let mut instance = Inline::<T, N>::new(capacity);
+            let mut instance = Inline::<T, N>::new();
 
             if capacity >= 1 {
                 let first_element = unsafe { instance.element_mut(0) };

--- a/src/containers/storage/mod.rs
+++ b/src/containers/storage/mod.rs
@@ -23,23 +23,9 @@ use core::mem::MaybeUninit;
 ///
 /// # Panics
 ///
-/// With the exception of [`new`](Storage::new), the methods in this trait are *not* allowed to panic when `cfg(debug_assertions)` is not enabled.
+/// The methods in this trait are *not* allowed to panic when `cfg(debug_assertions)` is not enabled.
 /// Implementors should use `debug_assert!` to check that preconditions are fulfilled.
 pub trait Storage<T> {
-    /// Creates a new instance with enough capacity for the given number of elements.
-    ///
-    /// # Panics
-    ///
-    /// This method is allowed to panic when `capacity` is invalid, or when not enough memory could be allocated.
-    fn new(capacity: u32) -> Self;
-
-    /// Tries to create a new instance with enough capacity for the given number of elements.
-    ///
-    /// Returns `None` if the allocation failed for any reason.
-    fn try_new(capacity: u32) -> Option<Self>
-    where
-        Self: Sized;
-
     /// Returns the allocated capacity.
     fn capacity(&self) -> u32;
 
@@ -73,44 +59,48 @@ pub trait Storage<T> {
 }
 
 #[cfg(test)]
-mod test_utils {
+pub(crate) mod test_utils {
     //! A simple impl of [`Storage`] for [`Vec`], to be used for tests of generic containers.
 
     use super::*;
     use core::ptr;
 
-    impl<T> Storage<T> for Vec<MaybeUninit<T>> {
-        fn new(capacity: u32) -> Self {
+    pub struct TestVec<T>(Vec<MaybeUninit<T>>);
+
+    impl<T> TestVec<T> {
+        pub fn new(capacity: usize) -> Self {
             Self::try_new(capacity).unwrap_or_else(|| panic!("failed to allocate for {capacity} elements"))
         }
 
-        fn try_new(capacity: u32) -> Option<Self>
+        pub fn try_new(capacity: usize) -> Option<Self>
         where
             Self: Sized,
         {
             let mut instance = vec![];
-            instance.try_reserve_exact(capacity as usize).ok()?;
+            instance.try_reserve_exact(capacity).ok()?;
             instance.extend((0..capacity).map(|_| MaybeUninit::zeroed()));
-            Some(instance)
+            Some(Self(instance))
         }
+    }
 
+    impl<T> Storage<T> for TestVec<T> {
         fn capacity(&self) -> u32 {
-            self.capacity() as u32
+            self.0.capacity() as u32
         }
 
         unsafe fn element(&self, index: u32) -> &MaybeUninit<T> {
-            &self[index as usize]
+            &self.0[index as usize]
         }
 
         unsafe fn element_mut(&mut self, index: u32) -> &mut MaybeUninit<T> {
-            &mut self[index as usize]
+            &mut self.0[index as usize]
         }
 
         unsafe fn subslice(&self, start: u32, end: u32) -> *const [T] {
             debug_assert!(start <= end);
             debug_assert!(end <= Storage::capacity(self));
             // SAFETY: `start` is in-bounds of the array, as per the pre-condition on the trait method.
-            let ptr = unsafe { self.as_ptr().add(start as usize).cast() };
+            let ptr = unsafe { self.0.as_ptr().add(start as usize).cast() };
             let len = end - start;
             ptr::slice_from_raw_parts(ptr, len as usize)
         }
@@ -119,7 +109,7 @@ mod test_utils {
             debug_assert!(start <= end);
             debug_assert!(end <= Storage::capacity(self));
             // SAFETY: `start` is in-bounds of the array, as per the pre-condition on the trait method.
-            let ptr = unsafe { self.as_mut_ptr().add(start as usize).cast() };
+            let ptr = unsafe { self.0.as_mut_ptr().add(start as usize).cast() };
             let len = end - start;
             ptr::slice_from_raw_parts_mut(ptr, len as usize)
         }

--- a/src/elementary/allocator_traits.rs
+++ b/src/elementary/allocator_traits.rs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
+use core::alloc::Layout;
 use core::ptr::NonNull;
 
 #[derive(Debug, Clone, Copy)]
@@ -27,7 +28,7 @@ pub enum AllocationError {
 
 pub trait BasicAllocator {
     /// Allocates a block of memory as described by `layout`.
-    fn allocate(&self, layout: core::alloc::Layout) -> Result<NonNull<[u8]>, AllocationError>;
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocationError>;
 
     /// Deallocates the memory block pointed to by `ptr` with the given `layout`.
     ///
@@ -35,5 +36,5 @@ pub trait BasicAllocator {
     ///  - `ptr` must have been allocated by a previous call to `allocate` with the same `layout`.
     ///  - `layout` must match the layout used during allocation.
     ///
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: core::alloc::Layout);
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
 }

--- a/src/elementary/heap_allocator.rs
+++ b/src/elementary/heap_allocator.rs
@@ -12,18 +12,22 @@
 // *******************************************************************************
 
 extern crate alloc;
-use alloc::alloc::alloc;
-use alloc::alloc::dealloc;
 
+use alloc::alloc::{alloc, dealloc};
+use core::alloc::Layout;
 use core::ptr::NonNull;
 
 use crate::allocator_traits::{AllocationError, BasicAllocator};
 
-#[derive(Debug, Clone, Copy)]
-pub struct GlobalAllocator;
+/// Global allocator.
+pub static GLOBAL_ALLOCATOR: HeapAllocator = HeapAllocator;
 
-impl BasicAllocator for GlobalAllocator {
-    fn allocate(&self, layout: core::alloc::Layout) -> Result<NonNull<[u8]>, AllocationError> {
+/// Proxy to global heap allocation in Rust.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HeapAllocator;
+
+impl BasicAllocator for HeapAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocationError> {
         if layout.size() == 0 {
             return Err(AllocationError::ZeroSizeAllocation);
         }
@@ -33,20 +37,13 @@ impl BasicAllocator for GlobalAllocator {
             if ptr.is_null() {
                 return Err(AllocationError::OutOfMemory);
             }
-            Ok(NonNull::slice_from_raw_parts(
-                NonNull::new_unchecked(ptr),
-                layout.size(),
-            ))
+
+            // SAFETY: already checked for null.
+            Ok(NonNull::new_unchecked(ptr))
         }
     }
 
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: core::alloc::Layout) {
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         dealloc(ptr.as_ptr(), layout);
-    }
-}
-
-impl Default for GlobalAllocator {
-    fn default() -> Self {
-        GlobalAllocator
     }
 }

--- a/src/elementary/lib.rs
+++ b/src/elementary/lib.rs
@@ -11,5 +11,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // *******************************************************************************
 
-pub mod allocator_traits;
-pub mod global_allocator;
+mod allocator_traits;
+mod heap_allocator;
+
+pub use allocator_traits::{AllocationError, BasicAllocator};
+pub use heap_allocator::{HeapAllocator, GLOBAL_ALLOCATOR};

--- a/src/sync/arc_in.rs
+++ b/src/sync/arc_in.rs
@@ -20,7 +20,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
 };
 
-use elementary::allocator_traits::BasicAllocator;
+use elementary::BasicAllocator;
 
 /// A reference-counted smart pointer with custom allocator support like `std::sync::Arc`.
 /// The `ArcIn` type provides shared ownership of a value of type `T`, allocated using the specified allocator `A`.
@@ -155,13 +155,13 @@ impl<T, A: BasicAllocator> Drop for ArcIn<T, A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use elementary::global_allocator::GlobalAllocator;
+    use elementary::HeapAllocator;
     use std::collections::hash_map::DefaultHasher;
     use std::hash::Hash;
 
     #[test]
     fn new_and_deref() {
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let arc = ArcIn::new_in(42, alloc);
         assert_eq!(*arc, 42);
         assert_eq!(ArcIn::strong_count(&arc), 1);
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn clone_increases_count() {
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let arc1 = ArcIn::new_in(100, alloc);
         let arc2 = arc1.clone();
         assert_eq!(ArcIn::strong_count(&arc1), 2);
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn drop_decreases_count() {
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let arc1 = ArcIn::new_in(55, alloc);
         assert_eq!(ArcIn::strong_count(&arc1), 1);
         {
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn debug_trait() {
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let arc = ArcIn::new_in("hello", alloc);
         let s = format!("{:?}", arc);
         assert_eq!(s, "\"hello\"");
@@ -199,14 +199,14 @@ mod tests {
 
     #[test]
     fn default_trait() {
-        let arc: ArcIn<u32, GlobalAllocator> = ArcIn::default();
+        let arc: ArcIn<u32, HeapAllocator> = ArcIn::default();
         assert_eq!(*arc, 0);
         assert_eq!(ArcIn::strong_count(&arc), 1);
     }
 
     #[test]
     fn as_ref_trait() {
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let arc = ArcIn::new_in("world".to_string(), alloc);
         let s: &str = arc.as_ref();
         assert_eq!(s, "world");
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn eq_ord_hash() {
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let arc1 = ArcIn::new_in(5, alloc);
         let arc2 = ArcIn::new_in(5, alloc);
         let arc3 = ArcIn::new_in(10, alloc);
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn strong_count_multiple_clones() {
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let arc = ArcIn::new_in(123, alloc);
         let clones: Vec<_> = (0..5).map(|_| arc.clone()).collect();
         assert_eq!(ArcIn::strong_count(&arc), 6);
@@ -250,7 +250,7 @@ mod tests {
             }
         }
 
-        let alloc = GlobalAllocator;
+        let alloc = HeapAllocator;
         let mut dropped = false;
         {
             let arc = ArcIn::new_in(DropCounter(&mut dropped), alloc);


### PR DESCRIPTION
Reworked abstraction to allow usage of custom allocator implementations.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #81 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
