### PR TITLE
fix: replace unstable NonNull::from_ref with stable equivalent

### DIFF
--- a/src/log/score_log_fmt/fmt.rs
+++ b/src/log/score_log_fmt/fmt.rs
@@ -71,7 +71,7 @@ pub struct Placeholder<'a> {
 impl<'a> Placeholder<'a> {
     /// Create the placeholder to be represented using `ScoreDebug`.
     pub const fn new<T: ScoreDebug>(value: &'a T, spec: FormatSpec) -> Self {
-        let value = NonNull::from_ref(value).cast();
+        let value = unsafe { NonNull::new_unchecked(value as *const _ as *mut ()).cast() };
         let formatter = |v: NonNull<()>, f: Writer, spec: &FormatSpec| {
             // SAFETY: borrow checker will ensure that value won't be mutated for as long as the returned `Self` instance is alive.
             let typed = unsafe { v.cast::<T>().as_ref() };

--- a/src/log/score_log_fmt/fmt_impl.rs
+++ b/src/log/score_log_fmt/fmt_impl.rs
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn test_from_utf8_error_debug() {
         let a1 = vec![0xa0, 0xa1];
-        let a2: Result<String, std::string::FromUtf8Error> = a1.try_into();
+        let a2: Result<String, std::string::FromUtf8Error> = String::from_utf8(a1);
         common_test_debug(a2.unwrap_err());
     }
 


### PR DESCRIPTION
Replace NonNull::from_ref usage in const fn context with stable alternative using NonNull::new_unchecked.

The NonNull::from_ref method exists in Rust 1.86+ but using it as a const fn is still unstable (requires nightly feature non_null_from_ref). This change enables compilation with stable Rust toolchains including Ferrocene.

Changes:
  NonNull::from_ref(value).cast()
to:
  unsafe { NonNull::new_unchecked(value as *const _ as *mut ()).cast() }

Both implementations are functionally equivalent and safe in this context due to the lifetime constraints enforced by the borrow checker.

Enables: aarch64-linux builds with stable Ferrocene toolchain
Related: https://github.com/rust-lang/rust/issues/130823

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
